### PR TITLE
OAUTH2-295 Maintain referential integrity only

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationScopeAliasesLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationScopeAliasesLocalServiceImpl.java
@@ -21,6 +21,7 @@ import com.liferay.oauth2.provider.scope.liferay.LiferayOAuth2Scope;
 import com.liferay.oauth2.provider.scope.liferay.ScopeLocator;
 import com.liferay.oauth2.provider.service.OAuth2ScopeGrantLocalService;
 import com.liferay.oauth2.provider.service.base.OAuth2ApplicationScopeAliasesLocalServiceBaseImpl;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -89,8 +90,14 @@ public class OAuth2ApplicationScopeAliasesLocalServiceImpl
 				_oAuth2ScopeGrantLocalService.getOAuth2AuthorizationPrimaryKeys(
 					oAuth2ScopeGrant.getOAuth2ScopeGrantId());
 
-			if (oAuth2AuthorizationPrimaryKeys.length < 1) {
-				return null;
+			if (oAuth2AuthorizationPrimaryKeys.length > 0) {
+				throw new PortalException(
+					StringBundler.concat(
+						"Cannot delete OAuth2ApplicationScopeAliases with ID ",
+						oAuth2ApplicationScopeAliasesId,
+						"because because there exists at least one ",
+						"OAuth2Authorization which references its ",
+						"OAuth2ScopeGrants"));
 			}
 		}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationScopeAliasesLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationScopeAliasesLocalServiceImpl.java
@@ -85,6 +85,16 @@ public class OAuth2ApplicationScopeAliasesLocalServiceImpl
 				QueryUtil.ALL_POS, null);
 
 		for (OAuth2ScopeGrant oAuth2ScopeGrant : oAuth2ScopeGrants) {
+			long[] oAuth2AuthorizationPrimaryKeys =
+				_oAuth2ScopeGrantLocalService.getOAuth2AuthorizationPrimaryKeys(
+					oAuth2ScopeGrant.getOAuth2ScopeGrantId());
+
+			if (oAuth2AuthorizationPrimaryKeys.length < 1) {
+				return null;
+			}
+		}
+
+		for (OAuth2ScopeGrant oAuth2ScopeGrant : oAuth2ScopeGrants) {
 			_oAuth2ScopeGrantLocalService.deleteOAuth2ScopeGrant(
 				oAuth2ScopeGrant.getOAuth2ScopeGrantId());
 		}


### PR DESCRIPTION
Hi Arthur. Following our discussion with @topolik earlier I think the 2nd approach you sent to me is as far as we should go right now. Rationale...

1) 3rd party developers calling this API method is unexpected behavior. So we only care about having the method do what is necessary which we call it whilst deleting OAuth2Applications.
2) We must guard against breaking referential integrity
3) It makes sense to revisit the logic when we review the OAuth 2 DB schema. We can make bigger changes then, if appropriate.

Please can you review and if you agree send it to BChan.