### PR TITLE
LPS-102770 Matching on module web contexts should be by full path

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/auth/AuthVerifierPipeline.java
+++ b/portal-impl/src/com/liferay/portal/security/auth/AuthVerifierPipeline.java
@@ -118,13 +118,11 @@ public class AuthVerifierPipeline {
 
 		String contextPath = httpServletRequest.getContextPath();
 
-		requestURI = requestURI.substring(contextPath.length());
-
 		for (AuthVerifierConfiguration authVerifierConfiguration :
 				_authVerifierConfigurations) {
 
 			authVerifierConfiguration = _mergeAuthVerifierConfiguration(
-				authVerifierConfiguration, accessControlContext);
+				authVerifierConfiguration, accessControlContext, contextPath);
 
 			if (_isMatchingRequestURI(authVerifierConfiguration, requestURI)) {
 				authVerifierConfigurations.add(authVerifierConfiguration);
@@ -165,7 +163,7 @@ public class AuthVerifierPipeline {
 
 	private AuthVerifierConfiguration _mergeAuthVerifierConfiguration(
 		AuthVerifierConfiguration authVerifierConfiguration,
-		AccessControlContext accessControlContext) {
+		AccessControlContext accessControlContext, String contextPath) {
 
 		Map<String, Object> settings = accessControlContext.getSettings();
 
@@ -211,8 +209,22 @@ public class AuthVerifierPipeline {
 					String propertiesKey = settingsKey.substring(
 						authVerifierSettingsKey.length());
 
-					mergedProperties.setProperty(
-						propertiesKey, (String)settingsValue);
+					if (propertiesKey.equals("urls.includes") ||
+						propertiesKey.equals("urls.excludes")) {
+
+						String settingsValueString = (String)settingsValue;
+
+						if (settingsValueString.charAt(0) != '/') {
+							settingsValueString = "/" + settingsValueString;
+						}
+
+						mergedProperties.setProperty(
+							propertiesKey, contextPath + settingsValueString);
+					}
+					else {
+						mergedProperties.setProperty(
+							propertiesKey, (String)settingsValue);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Hi Arthur. As discussed I am sending you what I've got for fixing the bug only.
This pull request should be a fully working solution. It allows the configurations mentioned in the ticket to apply to modules only when the web context is also included in the urls.includes. Meaning that it should no longer be applying unexpectedly.

My only concern is if this changes regresses LPS-30170 which claims excluding the context path when matching is necessary to support JSON-WS services from custom plugins. I have however tested using the Bookmarks web context which I think would be the same thing.

/cc @csierra