### PR TITLE
LPS-106686 Provide a URL for the MFA portlet's return to full page link

### DIFF
--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/src/main/java/com/liferay/multi/factor/authentication/email/otp/web/internal/portlet/action/LoginMVCActionCommand.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/src/main/java/com/liferay/multi/factor/authentication/email/otp/web/internal/portlet/action/LoginMVCActionCommand.java
@@ -53,6 +53,7 @@ import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
 import javax.portlet.ActionURL;
 import javax.portlet.PortletRequest;
+import javax.portlet.RenderURL;
 import javax.portlet.WindowState;
 import javax.portlet.filter.ActionRequestWrapper;
 
@@ -183,7 +184,8 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 	}
 
 	private LiferayPortletURL _getLiferayPortletURL(
-		HttpServletRequest httpServletRequest, String redirectURL) {
+		HttpServletRequest httpServletRequest, String redirectURL,
+		String returnToFullPageURL) {
 
 		httpServletRequest = _portal.getOriginalServletRequest(
 			httpServletRequest);
@@ -208,6 +210,9 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 		liferayPortletURL.setParameter(
 			"mvcRenderCommandName", "/mfa_email_otp_verify/verify");
 		liferayPortletURL.setParameter("redirect", redirectURL);
+
+		liferayPortletURL.setParameter(
+			"returnToFullPageURL", returnToFullPageURL);
 
 		return liferayPortletURL;
 	}
@@ -239,8 +244,18 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 			_portal.getOriginalServletRequest(
 				_portal.getHttpServletRequest(actionRequest));
 
+		String redirect = ParamUtil.getString(actionRequest, "redirect");
+
+		RenderURL returnToFullPageRenderURL =
+			liferayPortletResponse.createRenderURL();
+
+		if (Validator.isNotNull(redirect)) {
+			returnToFullPageRenderURL.setParameter("redirect", redirect);
+		}
+
 		LiferayPortletURL liferayPortletURL = _getLiferayPortletURL(
-			httpServletRequest, actionURL.toString());
+			httpServletRequest, actionURL.toString(),
+			returnToFullPageRenderURL.toString());
 
 		String portletId = ParamUtil.getString(httpServletRequest, "p_p_id");
 


### PR DESCRIPTION
Hi Arthur. We can provide a custom "return to full page" link URL to fix this problem. It can result in long URLs though.

I did some preliminary testing of MFA with the FAST_LOGIN portlet, and it looks like we can exclude this new URL in that login flow, maybe? If so then the URL can actually be generated from the MFA portlet side (no need to send it on the HTTP request).

/cc @csierra