### PR TITLE
LPS-113348 Add CORS tests using Basic and Portal Session

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-scope-liferay-api/src/main/java/com/liferay/oauth2/provider/scope/liferay/OAuth2ProviderScopeLiferayAccessControlContext.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-liferay-api/src/main/java/com/liferay/oauth2/provider/scope/liferay/OAuth2ProviderScopeLiferayAccessControlContext.java
@@ -29,11 +29,18 @@ public class OAuth2ProviderScopeLiferayAccessControlContext {
 		AccessControlContext accessControlContext =
 			AccessControlUtil.getAccessControlContext();
 
+		if (accessControlContext == null) {
+			return false;
+		}
+
 		AuthVerifierResult authVerifierResult =
 			accessControlContext.getAuthVerifierResult();
 
-		if ((authVerifierResult != null) &&
-			AuthVerifierResult.State.SUCCESS.equals(
+		if (authVerifierResult == null) {
+			return false;
+		}
+
+		if (AuthVerifierResult.State.SUCCESS.equals(
 				authVerifierResult.getState())) {
 
 			String authType = MapUtil.getString(

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/CORSApplicationClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/CORSApplicationClientTest.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.oauth2.provider.client.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Collections;
+
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.BundleActivator;
+
+/**
+ * @author Marta Medio
+ */
+@RunWith(Arquillian.class)
+public class CORSApplicationClientTest extends BaseClientTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testInvalidCORSRequest() throws Exception {
+		WebTarget webTarget = getJsonWebTarget("user", "get-current-user");
+
+		String tokenString = "wrong-token";
+
+		Invocation.Builder invocationBuilder = authorize(
+			webTarget.request(), tokenString);
+
+		invocationBuilder.header("Origin", _TEST_CORS_URI);
+
+		Response response = invocationBuilder.get();
+
+		String corsHeaderString = response.getHeaderString(
+			"Access-Control-Allow-Origin");
+
+		Assert.assertNotEquals(_TEST_CORS_URI, corsHeaderString);
+	}
+
+	@Test
+	public void testValidCORSRequest() throws Exception {
+		WebTarget webTarget = getJsonWebTarget("user", "get-current-user");
+
+		String tokenString = getToken(
+			"oauthTestApplicationRO", null,
+			getResourceOwnerPasswordBiFunction("test@liferay.com", "test"),
+			this::parseTokenString);
+
+		Invocation.Builder invocationBuilder = authorize(
+			webTarget.request(), tokenString);
+
+		invocationBuilder.header("Origin", _TEST_CORS_URI);
+
+		Response response = invocationBuilder.get();
+
+		String corsHeaderString = response.getHeaderString(
+			"Access-Control-Allow-Origin");
+
+		Assert.assertEquals(_TEST_CORS_URI, corsHeaderString);
+	}
+
+	public static class CORSApplicationTestPreparatorBundleActivator
+		extends BaseTestPreparatorBundleActivator {
+
+		@Override
+		protected void prepareTest() throws Exception {
+			long defaultCompanyId = PortalUtil.getDefaultCompanyId();
+
+			User user = UserTestUtil.getAdminUser(defaultCompanyId);
+
+			createOAuth2Application(
+				defaultCompanyId, user, "oauthTestApplicationRO",
+				Collections.singletonList("everything.read"));
+		}
+
+	}
+
+	@Override
+	protected BundleActivator getBundleActivator() {
+		return new CORSApplicationTestPreparatorBundleActivator();
+	}
+
+	private static final String _TEST_CORS_URI = "http://test-cors.com";
+
+}

--- a/modules/apps/portal-remote/portal-remote-cors-impl/build.gradle
+++ b/modules/apps/portal-remote/portal-remote-cors-impl/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.http.whiteboard", version: "1.0.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:oauth2-provider:oauth2-provider-scope-liferay-api")
 	compileOnly project(":apps:portal-remote:portal-remote-cors-api")
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")

--- a/modules/apps/portal-remote/portal-remote-cors-impl/src/main/java/com/liferay/portal/remote/cors/internal/servlet/filter/ConfigurablePortalCORSServletFilterPublisher.java
+++ b/modules/apps/portal-remote/portal-remote-cors-impl/src/main/java/com/liferay/portal/remote/cors/internal/servlet/filter/ConfigurablePortalCORSServletFilterPublisher.java
@@ -62,7 +62,7 @@ public class ConfigurablePortalCORSServletFilterPublisher {
 
 		Dictionary<String, Object> filterProperties = new HashMapDictionary<>();
 
-		filterProperties.put("before-filter", "Auto Login Filter");
+		filterProperties.put("before-filter", "Upload Servlet Request Filter");
 		filterProperties.put("dispatcher", new String[] {"FORWARD", "REQUEST"});
 		filterProperties.put("servlet-context-name", "");
 		filterProperties.put(

--- a/modules/apps/portal-remote/portal-remote-cors-test/build.gradle
+++ b/modules/apps/portal-remote/portal-remote-cors-test/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	testIntegrationCompile group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
+	testIntegrationCompile group: "org.apache.cxf", name: "cxf-rt-rs-client", version: "3.2.12"
 	testIntegrationCompile group: "org.osgi", name: "org.osgi.service.cm", version: "1.5.0"
 	testIntegrationCompile group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	testIntegrationCompile project(":apps:portal-remote:portal-remote-cors-api")

--- a/modules/apps/portal-remote/portal-remote-cors-test/src/testIntegration/java/com/liferay/portal/remote/cors/client/test/AllowRestrictedHeadersCallable.java
+++ b/modules/apps/portal-remote/portal-remote-cors-test/src/testIntegration/java/com/liferay/portal/remote/cors/client/test/AllowRestrictedHeadersCallable.java
@@ -16,6 +16,7 @@ package com.liferay.portal.remote.cors.client.test;
 
 import com.liferay.petra.process.ProcessCallable;
 import com.liferay.petra.process.ProcessException;
+import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.net.HttpURLConnection;
@@ -30,9 +31,13 @@ import java.util.Map;
 public class AllowRestrictedHeadersCallable
 	implements ProcessCallable<String[]> {
 
-	public AllowRestrictedHeadersCallable(String url, String origin) {
+	public AllowRestrictedHeadersCallable(
+		String url, String origin, String method, boolean authenticate) {
+
 		_url = url;
 		_origin = origin;
+		_method = method;
+		_authenticate = authenticate;
 	}
 
 	@Override
@@ -45,7 +50,15 @@ public class AllowRestrictedHeadersCallable
 
 			httpURLConnection.setRequestProperty("Origin", _origin);
 			httpURLConnection.setRequestProperty(
-				_ACCESS_CONTROL_REQUEST_METHOD, "GET");
+				_ACCESS_CONTROL_REQUEST_METHOD, _method);
+
+			if (_authenticate) {
+				String encodedUserNameAndPassword = Base64.encode(
+					"test@liferay.com:test".getBytes());
+
+				httpURLConnection.setRequestProperty(
+					"Authorization", "Basic " + encodedUserNameAndPassword);
+			}
 
 			Map<String, List<String>> headerFields =
 				httpURLConnection.getHeaderFields();
@@ -70,6 +83,8 @@ public class AllowRestrictedHeadersCallable
 
 	private static final long serialVersionUID = 1L;
 
+	private final boolean _authenticate;
+	private final String _method;
 	private final String _origin;
 	private final String _url;
 

--- a/modules/apps/portal-remote/portal-remote-cors-test/src/testIntegration/java/com/liferay/portal/remote/cors/client/test/CORSAnnotationClientTest.java
+++ b/modules/apps/portal-remote/portal-remote-cors-test/src/testIntegration/java/com/liferay/portal/remote/cors/client/test/CORSAnnotationClientTest.java
@@ -21,6 +21,8 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.Dictionary;
 
+import javax.ws.rs.HttpMethod;
+
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -49,7 +51,12 @@ public class CORSAnnotationClientTest extends BaseCORSClientTestCase {
 
 	@Test
 	public void testCORSApplication() throws Exception {
-		assertURL("/test/cors-app", true);
+		assertJaxRSUrl("/test/cors-app", HttpMethod.GET, true);
+	}
+
+	@Test
+	public void testCORSPrelightApplication() throws Exception {
+		assertJaxRSUrl("/test/cors-app", HttpMethod.OPTIONS, true);
 	}
 
 }

--- a/modules/apps/portal-remote/portal-remote-cors-test/src/testIntegration/java/com/liferay/portal/remote/cors/client/test/CORSConfigurationClientTest.java
+++ b/modules/apps/portal-remote/portal-remote-cors-test/src/testIntegration/java/com/liferay/portal/remote/cors/client/test/CORSConfigurationClientTest.java
@@ -17,9 +17,12 @@ package com.liferay.portal.remote.cors.client.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.util.HashMapDictionary;
+import com.liferay.portal.remote.cors.configuration.WebContextCORSConfiguration;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.Dictionary;
+
+import javax.ws.rs.HttpMethod;
 
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -52,7 +55,8 @@ public class CORSConfigurationClientTest extends BaseCORSClientTestCase {
 			"servlet.context.helper.select.filter",
 			"(osgi.jaxrs.name=test-cors)");
 
-		createFactoryConfiguration(properties);
+		createFactoryConfiguration(
+			WebContextCORSConfiguration.class.getName(), properties);
 
 		properties = new HashMapDictionary<>();
 
@@ -68,7 +72,8 @@ public class CORSConfigurationClientTest extends BaseCORSClientTestCase {
 			"servlet.context.helper.select.filter",
 			"(osgi.jaxrs.name=test-cors-url)");
 
-		createFactoryConfiguration(properties);
+		createFactoryConfiguration(
+			WebContextCORSConfiguration.class.getName(), properties);
 
 		registerJaxRsApplication(
 			new CORSTestApplication(), "no-cors", new HashMapDictionary<>());
@@ -87,15 +92,25 @@ public class CORSConfigurationClientTest extends BaseCORSClientTestCase {
 			"servlet.context.helper.select.filter",
 			"(osgi.jaxrs.name=test-cors-wrong-url)");
 
-		createFactoryConfiguration(properties);
+		createFactoryConfiguration(
+			WebContextCORSConfiguration.class.getName(), properties);
 	}
 
 	@Test
 	public void testCORSApplication() throws Exception {
-		assertURL("/cors/cors-app", true);
-		assertURL("/no-cors/cors-app", false);
-		assertURL("/test-cors-url/cors-app", true);
-		assertURL("/test-cors-wrong-url/cors-app", false);
+		assertJaxRSUrl("/cors/cors-app", HttpMethod.GET, true);
+		assertJaxRSUrl("/no-cors/cors-app", HttpMethod.GET, false);
+		assertJaxRSUrl("/test-cors-url/cors-app", HttpMethod.GET, true);
+		assertJaxRSUrl("/test-cors-wrong-url/cors-app", HttpMethod.GET, false);
+	}
+
+	@Test
+	public void testCORSPreflightApplication() throws Exception {
+		assertJaxRSUrl("/cors/cors-app", HttpMethod.OPTIONS, true);
+		assertJaxRSUrl("/no-cors/cors-app", HttpMethod.OPTIONS, false);
+		assertJaxRSUrl("/test-cors-url/cors-app", HttpMethod.OPTIONS, true);
+		assertJaxRSUrl(
+			"/test-cors-wrong-url/cors-app", HttpMethod.OPTIONS, false);
 	}
 
 }

--- a/modules/apps/portal-remote/portal-remote-cors-test/src/testIntegration/java/com/liferay/portal/remote/cors/client/test/CORSConfigurationPortalTest.java
+++ b/modules/apps/portal-remote/portal-remote-cors-test/src/testIntegration/java/com/liferay/portal/remote/cors/client/test/CORSConfigurationPortalTest.java
@@ -1,0 +1,197 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.remote.cors.client.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.util.CookieKeys;
+import com.liferay.portal.kernel.util.HashMapDictionary;
+import com.liferay.portal.remote.cors.configuration.PortalCORSConfiguration;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Dictionary;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.NewCookie;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.ext.RuntimeDelegate;
+
+import org.apache.cxf.jaxrs.client.spec.ClientBuilderImpl;
+import org.apache.cxf.jaxrs.impl.RuntimeDelegateImpl;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Marta Medio
+ */
+@RunWith(Arquillian.class)
+public class CORSConfigurationPortalTest extends BaseCORSClientTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testNoCORSUsingBasic() throws Exception {
+		assertJsonWSUrl("/user/get-current-user", HttpMethod.OPTIONS, false);
+		assertJsonWSUrl("/user/get-current-user", HttpMethod.GET, false);
+
+		Dictionary<String, Object> properties = new HashMapDictionary<>();
+
+		properties.put("configuration.name", "test-cors");
+
+		properties.put("filter.mapping.url.pattern", "/api/jsonws/*");
+
+		createFactoryConfiguration(
+			PortalCORSConfiguration.class.getName(), properties);
+
+		assertJsonWSUrl("/user/get-current-user", HttpMethod.OPTIONS, false);
+		assertJsonWSUrl("/user/get-current-user", HttpMethod.GET, false);
+	}
+
+	@Test
+	public void testNoCORSUsingPortalSession() throws Exception {
+		Invocation.Builder invocationBuilder = _getJsonWebTarget(
+			"user", "get-current-user"
+		).request();
+
+		Cookie authenticatedCookie = _getAuthenticatedCookie(
+			"test@liferay.com", "test");
+
+		invocationBuilder.accept(
+			"text/html"
+		).cookie(
+			authenticatedCookie
+		);
+
+		invocationBuilder.header("Origin", "http://test-cors.com");
+
+		Response response = invocationBuilder.get();
+
+		String corsHeaderString = response.getHeaderString(
+			"Access-Control-Allow-Origin");
+
+		Assert.assertNull(corsHeaderString);
+	}
+
+	private Cookie _getAuthenticatedCookie(String login, String password) {
+		Invocation.Builder invocationBuilder = _getPortalWebTarget().request();
+
+		Response response = invocationBuilder.get();
+
+		String pAuthToken = _parsePAuthToken(response);
+
+		Map<String, NewCookie> cookies = response.getCookies();
+
+		NewCookie newCookie = cookies.get(CookieKeys.JSESSIONID);
+
+		invocationBuilder = _getLoginWebTarget().request();
+
+		invocationBuilder.cookie(newCookie);
+
+		MultivaluedMap<String, String> formData = new MultivaluedHashMap<>();
+
+		formData.add("login", login);
+		formData.add("password", password);
+		formData.add("p_auth", pAuthToken);
+
+		response = invocationBuilder.post(Entity.form(formData));
+
+		cookies = response.getCookies();
+
+		newCookie = cookies.get(CookieKeys.JSESSIONID);
+
+		if (newCookie == null) {
+			return null;
+		}
+
+		return newCookie.toCookie();
+	}
+
+	private WebTarget _getJsonWebTarget(String... paths) {
+		WebTarget webTarget = _getWebTarget();
+
+		webTarget = webTarget.path("api");
+		webTarget = webTarget.path("jsonws");
+
+		for (String path : paths) {
+			webTarget = webTarget.path(path);
+		}
+
+		return webTarget;
+	}
+
+	private WebTarget _getLoginWebTarget() {
+		WebTarget webTarget = _getWebTarget();
+
+		webTarget = webTarget.path("c");
+		webTarget = webTarget.path("portal");
+		webTarget = webTarget.path("login");
+
+		return webTarget;
+	}
+
+	private WebTarget _getPortalWebTarget() {
+		WebTarget webTarget = _getWebTarget();
+
+		webTarget = webTarget.path("web");
+		webTarget = webTarget.path("guest");
+
+		return webTarget;
+	}
+
+	private WebTarget _getWebTarget() {
+		ClientBuilder clientBuilder = new ClientBuilderImpl();
+
+		Client client = clientBuilder.build();
+
+		RuntimeDelegate runtimeDelegate = new RuntimeDelegateImpl();
+
+		UriBuilder uriBuilder = runtimeDelegate.createUriBuilder();
+
+		return client.target(uriBuilder.uri("http://localhost:8080"));
+	}
+
+	private String _parsePAuthToken(Response response) {
+		String bodyContent = response.readEntity(String.class);
+
+		Matcher matcher = _pAuthTokenPattern.matcher(bodyContent);
+
+		matcher.find();
+
+		return matcher.group(2);
+	}
+
+	private static final Pattern _pAuthTokenPattern = Pattern.compile(
+		"Liferay.authToken\\s*=\\s*(['\"])(((?!\\1).)*)\\1;");
+
+}


### PR DESCRIPTION
Hey @arthurchan35 👋 

Please, take a look at the CORS changes included in this PR taking into account:
- It's been decided that CORS should only apply if it's the request is a valid OAuth2 request
- Different request test cases have been added that were not covered (if you can think of any more cases to check, please, let me know!)

Thanks!

cc/ @csierra 