### PR TITLE
LPS-111617 Add unit test for URLPatternMatcher

### DIFF
--- a/modules/apps/portal-remote/portal-remote-cors-impl/src/main/java/com/liferay/portal/remote/cors/internal/URLtoCORSSupportMapper.java
+++ b/modules/apps/portal-remote/portal-remote-cors-impl/src/main/java/com/liferay/portal/remote/cors/internal/URLtoCORSSupportMapper.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.remote.cors.internal;
 
+import com.liferay.portal.kernel.util.Validator;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -34,7 +36,17 @@ public class URLtoCORSSupportMapper {
 	}
 
 	public CORSSupport get(String urlPath) {
+		if (Validator.isNull(urlPath)) {
+			return null;
+		}
+
 		CORSSupport corsSupport = _exactURLPatternCORSSupports.get(urlPath);
+
+		if (corsSupport != null) {
+			return corsSupport;
+		}
+
+		corsSupport = _wildcardURLPatternCORSSupports.get(urlPath + "/*");
 
 		if (corsSupport != null) {
 			return corsSupport;
@@ -43,15 +55,19 @@ public class URLtoCORSSupportMapper {
 		int index = 0;
 
 		for (int i = urlPath.length(); i > 0; --i) {
+			if ((index < 1) && (urlPath.charAt(i - 1) == '.')) {
+				index = i - 1;
+			}
+
+			if (urlPath.charAt(i - 1) != '/') {
+				continue;
+			}
+
 			corsSupport = _wildcardURLPatternCORSSupports.get(
 				urlPath.substring(0, i) + "*");
 
 			if (corsSupport != null) {
 				return corsSupport;
-			}
-
-			if ((index < 1) && (urlPath.charAt(i - 1) == '.')) {
-				index = i - 1;
 			}
 		}
 

--- a/modules/apps/portal-remote/portal-remote-cors-impl/src/test/java/com/liferay/portal/remote/cors/internal/URLtoCORSSupportMapperTest.java
+++ b/modules/apps/portal-remote/portal-remote-cors-impl/src/test/java/com/liferay/portal/remote/cors/internal/URLtoCORSSupportMapperTest.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.remote.cors.internal;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.KeyValuePair;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.ComparisonFailure;
+import org.junit.Test;
+
+/**
+ * @author Arthur Chan
+ */
+public class URLtoCORSSupportMapperTest {
+
+	@Test
+	public void testGet() throws Exception {
+		Map<String, CORSSupport> corsSupports = new HashMap<>();
+
+		for (KeyValuePair keyValuePair : _KEY_VALUE_PAIRS) {
+			CORSSupport corsSupport = new CORSSupport();
+
+			corsSupport.setHeader("pattern", keyValuePair.getValue());
+
+			corsSupports.put(keyValuePair.getValue(), corsSupport);
+		}
+
+		URLtoCORSSupportMapper urLtoCORSSupportMapper =
+			new URLtoCORSSupportMapper(corsSupports);
+
+		for (KeyValuePair keyValuePair : _KEY_VALUE_PAIRS) {
+			CORSSupport corsSupport = urLtoCORSSupportMapper.get(
+				keyValuePair.getKey());
+
+			if (corsSupport == null) {
+				Assert.assertEquals(StringPool.BLANK, keyValuePair.getValue());
+
+				continue;
+			}
+
+			Map<String, String> headers = new HashMap<>();
+
+			corsSupport.writeResponseHeaders(__ -> "origin", headers::put);
+
+			try {
+				Assert.assertEquals(
+					keyValuePair.getValue(), headers.get("pattern"));
+			}
+			catch (ComparisonFailure comparisonFailure) {
+				throw new ComparisonFailure(
+					"When testing " + keyValuePair.getKey() + ":",
+					comparisonFailure.getExpected(),
+					comparisonFailure.getActual());
+			}
+		}
+	}
+
+	private static final KeyValuePair[] _KEY_VALUE_PAIRS = {
+		new KeyValuePair("/", "//*"), new KeyValuePair("/*", "/*/*"),
+		new KeyValuePair("/*/", "/*//*"),
+		new KeyValuePair("/c/portal/j_login", "/c/portal/j_login"),
+		new KeyValuePair("/documents", "/documents/*"),
+		new KeyValuePair("/documents/", "/documents/*"),
+		new KeyValuePair("/documents/main.jsp", "/documents/main.jsp/*"),
+		new KeyValuePair("/documents/main.jsp/*", "/documents/main.jsp/*"),
+		new KeyValuePair("/documents/main.jspf", "/documents/main.jspf/*"),
+		new KeyValuePair("/documents/main.jspf/", "/documents/main.jspf/*"),
+		new KeyValuePair("/documents/user1", "/documents/user1/*"),
+		new KeyValuePair("/documents/user1/", "/documents/user1/*"),
+		new KeyValuePair(
+			"/documents/user1/folder1", "/documents/user1/folder1/*"),
+		new KeyValuePair(
+			"/documents/user1/folder1/", "/documents/user1/folder1/*"),
+		new KeyValuePair(
+			"/documents/user1/folder2", "/documents/user1/folder2/*"),
+		new KeyValuePair(
+			"/documents/user1/folder2/", "/documents/user1/folder2/*"),
+		new KeyValuePair("/documents/user2", "/documents/user2/*"),
+		new KeyValuePair("/documents/user2/", "/documents/user2/*"),
+		new KeyValuePair(
+			"/documents/user2/folder1", "/documents/user2/folder1/*"),
+		new KeyValuePair(
+			"/documents/user2/folder1/", "/documents/user2/folder1/*"),
+		new KeyValuePair(
+			"/documents/user2/folder2", "/documents/user2/folder2/*"),
+		new KeyValuePair(
+			"/documents/user2/folder2/", "/documents/user2/folder2/*"),
+		new KeyValuePair("/documents/user3", "/documents/*"),
+		new KeyValuePair("/documents/user3/", "/documents/*"),
+		new KeyValuePair("/documents/user3/folder1", "/documents/*"),
+		new KeyValuePair("/documents/user3/folder1/", "/documents/*"),
+		new KeyValuePair("/documents/user3/folder2", "/documents/*"),
+		new KeyValuePair("/documents/user3/folder2/", "/documents/*"),
+		new KeyValuePair("/test", "/*"), new KeyValuePair("/test/", "/*"),
+		new KeyValuePair("no/leading/slash", StringPool.BLANK),
+		new KeyValuePair("no/leading/slash/", StringPool.BLANK),
+		new KeyValuePair("no/leading/slash/*", "no/leading/slash/*"),
+		new KeyValuePair("no/leading/slash/test", StringPool.BLANK),
+		new KeyValuePair("test", StringPool.BLANK),
+		new KeyValuePair("test.jsp", "*.jsp"),
+		new KeyValuePair("test.jspf/", StringPool.BLANK),
+		new KeyValuePair("test/", StringPool.BLANK),
+		new KeyValuePair("test/main.jsp/*", StringPool.BLANK),
+		new KeyValuePair("test/main.jspf", "*.jspf")
+	};
+
+}


### PR DESCRIPTION
Hey Arthur, 

here I created a unit test that should be easily portable to the incoming matchers. Alas it does not work. I don't know why. I ported the tests that we have in the benchmarks, so it would mean that the current simple implementation is not working according to the spec.

That's the reason I am sending it for your review first before sending it to Brian. 

Here in this test we can see how removing the `<T>` parameter makes everything more complicated, since we are forced now to instantiate CORSSupport classes when the _mapper_ does not use the contained class at all. 

The branch is on liferay-appsec repo so you should be able to append commits to the branch. 

Thanks. 

Carlos.